### PR TITLE
Add ability to specify user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 
+git_config_user: "{{ lookup('env','USER') }}"
 git_config:
   user:
     name: Your Name

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -3,5 +3,7 @@
 - name: Configure .gitconfig file
   template:
     src=gitconfig.j2
-    dest=~/.gitconfig
+    dest="~{{ git_config_user }}/.gitconfig"
+    owner="{{ git_config_user }}"
+    group="{{ git_config_user }}"
   when: git_config

--- a/tasks/ignore.yml
+++ b/tasks/ignore.yml
@@ -3,5 +3,7 @@
 - name: Add all gitignore files
   template:
     src=gitignore.j2
-    dest="{{ git_config.core.excludesfile }}"
+    dest="~{{ git_config_user }}/{{ git_config.core.excludesfile | basename }}"
+    owner="{{ git_config_user }}"
+    group="{{ git_config_user }}"
   when: git_ignore and git_config.core is defined and git_config.core.excludesfile is defined


### PR DESCRIPTION
Hi, Simon!
I'd like to be able to render gitconfig for user other than the one who invokes ansible.
use case:
sysadmin generates default gitconfig for user
